### PR TITLE
Adapt the component-outlet to rc6

### DIFF
--- a/src/component-outlet.ts
+++ b/src/component-outlet.ts
@@ -1,18 +1,13 @@
-import {
-  Component,
-  ComponentMetadata,
-  Compiler,
-  Directive,
-  Input,
-  ViewContainerRef,
-  ReflectiveInjector
-} from '@angular/core';
+import { NgModule, Component, ComponentFactory, ComponentMetadata, NgModuleMetadataType,
+	Directive, Input, ViewContainerRef, Compiler, ReflectiveInjector } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 
 /**
  * ComponentOutlet is a directive to create dynamic component.
- * 
- * Example: 
- * 
+ *
+ * Example:
+ *
  * ```ts
  * @Component({
  *   selector: 'my-app',
@@ -23,16 +18,16 @@ import {
  * })
  * export class AppComponent {
  *   self = this;
- * 
+ *
  *   template = `
  *   <div>
  *     <p>Dynamic Component</p>
  *   </div>`;
  * }
  * ```
- * 
- * Result: 
- * 
+ *
+ * Result:
+ *
  * ```html
  * <my-component>
  *    <div>
@@ -40,38 +35,47 @@ import {
  *    </div>
  * </my-component>
  * ```
- * 
+ *
  */
-@Directive({
-  selector: '[componentOutlet]',
-})
-export class ComponentOutlet {
-  @Input('componentOutlet') private template: string;
-  @Input('componentOutletSelector') private selector: string;
-  @Input('componentOutletContext') private context: Object;
+ @Directive({
+ 	selector: '[componentOutlet]',
+ })
+ export class ComponentOutlet {
+ 	@Input('componentOutlet') private template: string;
+ 	@Input('componentOutletSelector') private selector: string;
+ 	@Input('componentOutletContext') private context: Object;
 
-  constructor(private vcRef: ViewContainerRef, private compiler: Compiler) { }
+ 	constructor(private vcRef: ViewContainerRef, private compiler: Compiler) {
 
-  private _createDynamicComponent() {
-    this.context = this.context || {};
+ 	}
 
-    const metadata = new ComponentMetadata({
-      selector: this.selector,
-      template: this.template,
-    });
+ 	private _createDynamicComponent() {
+ 		const metadata = new ComponentMetadata({
+ 			selector: this.selector,
+ 			template: this.template,
+ 		});
 
-    const cmpClass = class _ { };
-    cmpClass.prototype = this.context;
-    return Component(metadata)(cmpClass);
-  }
+ 		const cmpClass = class _ { };
+ 		cmpClass.prototype = this.context;
 
-  ngOnChanges() {
-    if (!this.template) return;
-    this.compiler.compileComponentAsync(this._createDynamicComponent())
-      .then(factory => {
-        const injector = ReflectiveInjector.fromResolvedProviders([], this.vcRef.parentInjector);
-        this.vcRef.clear();
-        this.vcRef.createComponent(factory, 0, injector);
-      });
-  }
-}
+ 		let component = Component(metadata)(cmpClass);
+
+ 		const mdClass = class _ { };
+ 		mdClass.prototype = {};
+ 		return NgModule({
+ 			imports: [BrowserModule, FormsModule],
+ 			declarations: [component],
+ 			exports: [component],
+ 			providers: []
+ 		})(mdClass);
+ 	}
+
+ 	ngOnChanges() {
+ 		if (!this.template) return;
+ 		this.compiler.compileModuleAndAllComponentsAsync(this._createDynamicComponent())
+ 		.then(factory => {
+ 			const injector = ReflectiveInjector.fromResolvedProviders([], this.vcRef.parentInjector);
+ 			this.vcRef.createComponent(factory.componentFactories[0], 0, injector);
+ 		});
+ 	}
+ }


### PR DESCRIPTION
This component works (mostly) with the latest release candidate of angular2, while using the same @Input-interface. Unfortunately, at the moment only simple html-constructs are support - angular-directives can not be parsed, yet.
