### PR TITLE
feat(implicit-context): Assign context to component instance.

### DIFF
--- a/src/component-outlet.spec.ts
+++ b/src/component-outlet.spec.ts
@@ -12,7 +12,7 @@ class TestCmp {
         flag: true,
         text: 'Dynamic'
     };
-    template = `<div><p *ngIf="context.flag">{{context.text}}</p></div>`;
+    template = `<div><p *ngIf="flag">{{text}}</p></div>`;
 }
 
 @Component({
@@ -25,14 +25,14 @@ class TestCmp {
 class MultipleCmp {
     list = [
         {
-            template: `<div>{{context.text}}</div>`,
+            template: `<div>{{text}}</div>`,
             context: {
                 text: 'Dynamic-1'
             },
             selector: 'my-component'
         },
         {
-            template: `<div>{{context.text}}</div>`,
+            template: `<div>{{text}}</div>`,
             context: {
                 text: 'Dynamic-2'
             },

--- a/src/component-outlet.ts
+++ b/src/component-outlet.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  ComponentFactoryResolver,
   ComponentRef,
   Compiler,
   Directive,
@@ -68,19 +67,13 @@ export class ComponentOutlet implements OnDestroy {
   ) { }
 
   private _createDynamicComponent(): Type<any> {
-    let ctx = this.context;
 
     const metadata = new Component({
       selector: this.selector,
       template: this.template,
     });
 
-    const cmpClass = class _ implements OnDestroy {
-      context = ctx;
-
-      ngOnDestroy() {
-        ctx = null;
-      }
+    const cmpClass = class _ {
     };
 
     return Component(metadata)(cmpClass);
@@ -95,7 +88,7 @@ export class ComponentOutlet implements OnDestroy {
       schemas: this.moduleMeta.schemas,
       declarations: declarations
     };
-    return NgModule(moduleMeta)(class _ { })
+    return NgModule(moduleMeta)(class _ { });
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -118,6 +111,7 @@ export class ComponentOutlet implements OnDestroy {
         if (cmpFactory) {
           this.vcRef.clear();
           this.component = this.vcRef.createComponent(cmpFactory, 0, injector);
+          Object.assign(this.component.instance, this.context);
           this.component.changeDetectorRef.detectChanges();
         }
       });


### PR DESCRIPTION
Assign context to the component instance instead assign context to `context` property to access to the context properties directly from template without use `context.` preffix.
Closes #23 
